### PR TITLE
Fix of an exception when sending a GET request after a POST

### DIFF
--- a/anixart/request_handler.py
+++ b/anixart/request_handler.py
@@ -86,6 +86,8 @@ class AnixartRequestsHandler:
             if token is not None:
                 payload.update({"token": token})
         self.__log.debug(_log_name, 101, f"GET {method}; {payload}")
+        self.__session.headers.pop("Content-Type", None)
+        self.__session.headers.pop("Content-Length", None)
         res = self.__session.get(API_URL + method, params=payload)
         _parse_res_code(res, payload, "GET", self.__session.headers)
         return res


### PR DESCRIPTION
# Описание
При отправке `GET` запроса после `POST` из-за ответа сервера кодом `400` функция [_parse_res_code](https://github.com/SantaSpeen/anixart/blob/master/anixart/request_handler.py#L13) падает при невозможности перекодировать `html` ответ в `json` формат.

# Воспроизведение
``` python
from anixart import AnixartUserAccount, AnixartAPI, PROFILE, EDIT_STATUS

user = AnixartUserAccount(LOGIN, PASSWORD)
anix = AnixartAPI(user)

if __name__ == '__main__':
    print(me_info := anix.execute('GET', PROFILE.format(user.id)).json())
    print(anix.execute('POST', EDIT_STATUS, payload={'status': me_info['profile']['status']}, is_json=True).json())
    print(anix.execute('GET', PROFILE.format(user.id)).json())
```

# Причина и решение
Добавить в метод класса [AnixartRequestsHandler.get](https://github.com/SantaSpeen/anixart/blob/master/anixart/request_handler.py#L78) перед отправкой запроса строки, удаляющие сессионные хеадеры `Content-Type` и `Content-Length`, которые и провоцируют болезненный ответ сервера.

# Рекомендации
- добавить проверку на то, что полученные от сервера данные действительно являются `json`
- добавить проверку статус кода от сервера и при отличной от 200 не вызывать метод объекта ответа `.json()`